### PR TITLE
update Microprofile and webprofile7 image to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM websphere-liberty:19.0.0.3-webProfile7
+FROM websphere-liberty:webProfile7
 # FROM websphere-liberty@sha256:e99527c9275af659208e8ee28c9935f2f6c88cf24cf1819558578d8ddbcad112
 LABEL maintainer="IBM Java Engineering at IBM Cloud"
 COPY /target/liberty/wlp/usr/servers/defaultServer /config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM websphere-liberty:webProfile7
-# FROM websphere-liberty@sha256:e99527c9275af659208e8ee28c9935f2f6c88cf24cf1819558578d8ddbcad112
+FROM websphere-liberty:19.0.0.9-webProfile7
+
 LABEL maintainer="IBM Java Engineering at IBM Cloud"
 COPY /target/liberty/wlp/usr/servers/defaultServer /config/
 COPY /target/liberty/wlp/usr/shared/resources /config/resources/

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>1.2</version>
+            <version>3.2</version>
             <scope>provided</scope>
             <type>pom</type>
         </dependency>
@@ -400,7 +400,7 @@
                             <assemblyArtifact>
                                 <groupId>com.ibm.websphere.appserver.runtime</groupId>
                                 <artifactId>wlp-webProfile7</artifactId>
-                                <version>19.0.0.1</version>
+                                <version>[18.0.0.1,)</version>
                                 <type>zip</type>
                             </assemblyArtifact>
                             <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -1,12 +1,8 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-      <feature>microprofile-1.2</feature>
+      <feature>microprofile-3.2</feature>
       <feature>jndi-1.0</feature>
-      <feature>jsp-2.3</feature>
-      <feature>servlet-3.1</feature>
-      <feature>managedBeans-1.0</feature>
-      <feature>websocket-1.1</feature>
   </featureManager>
 
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"


### PR DESCRIPTION
Microprofile is now on 3.2 and we were still using 1.2

This change updates us to the latest

https://github.com/eclipse/microprofile/releases/tag/3.2

Signed-off-by: Toby Corbin <corbint@uk.ibm.com>