### PR TITLE
Add back the websocket-1.1 feature

### DIFF
--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -3,6 +3,7 @@
   <featureManager>
       <feature>microprofile-3.0</feature>
       <feature>jndi-1.0</feature>
+      <feature>websocket-1.1</feature>
   </featureManager>
 
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"


### PR DESCRIPTION
this is needed to enable metrics to be collected when running in a kube environment